### PR TITLE
feat: add pretest script to run build before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
 		"git:unit-staged": "npm run test:unit",
 		"git:test-staged": "npm run git:unit-staged",
 		"lint": "biome check --write --no-errors-on-unmatched",
+		"pretest": "npm run build",
 		"test": "npm run test:lint && npm run test:unit && npm run test:types && npm run test:sast && npm run test:perf && npm run test:dast",
 		"test:sast": "npm run test:sast:license && npm run test:sast:lockfile && npm run test:sast:semgrep && npm run test:sast:trufflehog && npm run test:sast:trivy",
 		"test:sast:license": "license-check-and-add check -f license.json",


### PR DESCRIPTION
## Summary
- Add `"pretest": "npm run build"` so that `npm test` automatically builds first
- Ensures tests always run against freshly built artifacts

## Test plan
- [ ] Verify `npm test` triggers build first
- [ ] Verify CI `Tests (unit)` etc. pick up latest build