### PR TITLE
feat: add 'License headers' job to test-sast.yml

### DIFF
--- a/.github/workflows/test-sast.yml
+++ b/.github/workflows/test-sast.yml
@@ -13,7 +13,27 @@ permissions:
   contents: read
 
 jobs:
-  lockfile-lint:
+license:
+    name: "License headers"
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts
+      - name: License check
+        run: |
+          npm run test:sast:license  lockfile-lint:
     name: 'lockfile-lint: SAST package-lock.json'
     runs-on: ubuntu-latest
     if: (github.actor != 'dependabot[bot]')

--- a/.github/workflows/test-sast.yml
+++ b/.github/workflows/test-sast.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-license:
+  license:
     name: "License headers"
     runs-on: ubuntu-latest
     if: (github.actor != 'dependabot[bot]')
@@ -33,7 +33,9 @@ license:
           npm ci --ignore-scripts
       - name: License check
         run: |
-          npm run test:sast:license  lockfile-lint:
+          npm run test:sast:license
+
+  lockfile-lint:
     name: 'lockfile-lint: SAST package-lock.json'
     runs-on: ubuntu-latest
     if: (github.actor != 'dependabot[bot]')


### PR DESCRIPTION
## Summary
- Add `license` job to `test-sast.yml` that runs `npm run test:sast:license` (license-check-and-add)
- Creates new `License headers` status check

## Test plan
- [ ] Verify `License headers` status check appears and passes on PRs
- [ ] Once merged, add `License headers` to main ruleset required status checks